### PR TITLE
refual-additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,15 +22,17 @@ of that partition or node.
 
 Set `slurm_upgrade` true to upgrade.
 
-You can use `slurm_user` (a hash) and `slurm_create_user` (a bool) to pre-create a Slurm user (so that uids match). See 
+You can use `slurm_user` (a hash) and `slurm_create_user` (a bool) to pre-create a Slurm user (so that uids match). See
 
 Dependencies
 ------------
 
 None.
 
-Example Playbook
-----------------
+Example Playbooks
+-----------------
+
+Minimal setup, all services on one node:
 
 ```yaml
 - name: Slurm all in One
@@ -39,6 +41,79 @@ Example Playbook
     slurm_roles: ['controller', 'exec', 'dbd']
   roles:
     - galaxyproject.slurm
+```
+
+More extensive example:
+
+```yaml
+- name: Slurm execution hosts
+  hosts: all
+  roles:
+    - galaxyproject.slurm
+  vars:
+    slurm_cgroup_config:
+      CgroupMountpoint: "/sys/fs/cgroup"
+      CgroupAutomount: yes
+      CgroupReleaseAgentDir: "/etc/slurm/cgroup"
+      ConstrainCores: yes
+      TaskAffinity: no
+      ConstrainRAMSpace: yes
+      ConstrainSwapSpace: no
+      ConstrainDevices: no
+      AllowedRamSpace: 100
+      AllowedSwapSpace: 0
+      MaxRAMPercent: 100
+      MaxSwapPercent: 100
+      MinRAMSpace: 30
+    slurm_config:
+      AccountingStorageType: "accounting_storage/none"
+      ClusterName: cluster
+      FastSchedule: 1
+      GresTypes: gpu
+      JobAcctGatherType: "jobacct_gather/none"
+      MpiDefault: none
+      ProctrackType: "proctrack/cgroup"
+      ReturnToService: 1
+      SchedulerType: "sched/backfill"
+      SelectType: "select/cons_res"
+      SelectTypeParameters: "CR_Core"
+      SlurmctldHost: "slurmctl"
+      SlurmctldLogFile: "/var/log/slurm/slurmctld.log"
+      SlurmctldPidFile: "/var/run/slurmctld.pid"
+      SlurmdLogFile: "/var/log/slurm/slurmd.log"
+      SlurmdPidFile: "/var/run/slurmd.pid"
+      SlurmdSpoolDir: "/var/spool/slurmd"
+      StateSaveLocation: "/var/spool/slurmctld"
+      SwitchType: "switch/none"
+      TaskPlugin: "task/affinity,task/cgroup"
+      TaskPluginParam: Sched
+    slurm_create_user: yes
+    slurm_gres_config:
+      - File: /dev/nvidia[0-3]
+        Name: gpu
+        NodeName: gpu[01-10]
+        Type: tesla
+    slurm_munge_key: "../../../munge.key"
+    slurm_nodes:
+      - name: "gpu[01-10]"
+        CoresPerSocket: 18
+        Gres: "gpu:tesla:4"
+        Sockets: 2
+        ThreadsPerCore: 2
+    slurm_partitions:
+      - name: gpu
+        Default: YES
+        MaxTime: UNLIMITED
+        Nodes: "gpu[01-10]"
+    slurm_roles: ['exec']
+    slurm_user:
+      comment: "Slurm Workload Manager"
+      gid: 888
+      group: slurm
+      home: "/var/lib/slurm"
+      name: slurm
+      shell: "/usr/sbin/nologin"
+      uid: 888
 ```
 
 License

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 Slurm
 =====
 
-Install and configure Slurm
+Install and configure a Slurm cluster on RHEL/CentOS or Debian/Ubuntu servers
 
 Role Variables
 --------------
 
-All variables are optional. If nothing is set, the role will install the Slurm client programs, munge, and create a `slurm.conf` with a single `localhost` node and `debug` partition. See the [defaults](defaults/main.yml) and [example playbooks](#example-playbooks) for examples.
+All variables are optional. If nothing is set, the role will install the Slurm client programs, munge, and
+create a `slurm.conf` with a single `localhost` node and `debug` partition.
+See the [defaults](defaults/main.yml) and [example playbooks](#example-playbooks) for examples.
 
 For the various roles a slurm node can play, you can either set group names, or add values to a list, `slurm_roles`.
 
@@ -14,15 +16,23 @@ For the various roles a slurm node can play, you can either set group names, or 
 - group slurmexechosts or `slurm_roles: ['exec']`
 - group slurmdbdservers or `slurm_roles: ['dbd']`
 
-General config options for slurm.conf go in `slurm_config`, a hash. Keys are slurm config option names.
+General config options for slurm.conf go in `slurm_config`, a hash. Keys are Slurm config option names.
 
 Partitions and nodes go in `slurm_partitions` and `slurm_nodes`, lists of hashes. The only required key in the hash is
 `name`, which becomes the `PartitionName` or `NodeName` for that line. All other keys/values are placed on to the line
 of that partition or node.
 
-Set `slurm_upgrade` true to upgrade.
+Options for the additional configuration files [acct_gather.conf](https://slurm.schedmd.com/acct_gather.conf.html),
+[cgroup.conf](https://slurm.schedmd.com/cgroup.conf.html) and [gres.conf](https://slurm.schedmd.com/gres.conf.html)
+may be specified in the `slurm_acct_gather_config`, `slurm_cgroup_config` (both of them hashes) and
+`slurm_gres_config` (list of hashes) respectively.
 
-You can use `slurm_user` (a hash) and `slurm_create_user` (a bool) to pre-create a Slurm user (so that uids match). See
+Set `slurm_upgrade` to true to upgrade the installed Slurm packages.
+
+You can use `slurm_user` (a hash) and `slurm_create_user` (a bool) to pre-create a Slurm user so that uids match.
+
+Note that this role requires root access, so enable ``become`` either globally in your playbook / on the commandline or
+just for the role like [shown below](#example-playbooks).
 
 Dependencies
 ------------
@@ -40,7 +50,8 @@ Minimal setup, all services on one node:
   vars:
     slurm_roles: ['controller', 'exec', 'dbd']
   roles:
-    - galaxyproject.slurm
+    - role: galaxyproject.slurm
+      become: True
 ```
 
 More extensive example:
@@ -49,12 +60,12 @@ More extensive example:
 - name: Slurm execution hosts
   hosts: all
   roles:
-    - galaxyproject.slurm
+    - role: galaxyproject.slurm
+      become: True
   vars:
     slurm_cgroup_config:
       CgroupMountpoint: "/sys/fs/cgroup"
       CgroupAutomount: yes
-      CgroupReleaseAgentDir: "/etc/slurm/cgroup"
       ConstrainCores: yes
       TaskAffinity: no
       ConstrainRAMSpace: yes
@@ -68,7 +79,6 @@ More extensive example:
     slurm_config:
       AccountingStorageType: "accounting_storage/none"
       ClusterName: cluster
-      FastSchedule: 1
       GresTypes: gpu
       JobAcctGatherType: "jobacct_gather/none"
       MpiDefault: none

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Install and configure Slurm
 Role Variables
 --------------
 
-All variables are optional. If nothing is set, the role will install the Slurm client programs, munge, and create a `slurm.conf` with a single `localhost` node and `debug` partition. See the [defaults](defaults/main.yml) and [example playbook](#example-playbook) for examples.
+All variables are optional. If nothing is set, the role will install the Slurm client programs, munge, and create a `slurm.conf` with a single `localhost` node and `debug` partition. See the [defaults](defaults/main.yml) and [example playbooks](#example-playbooks) for examples.
 
 For the various roles a slurm node can play, you can either set group names, or add values to a list, `slurm_roles`.
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: restart munge
+  service:
+    name: munge
+    state: restarted
 
 - name: reload slurmd
   service:

--- a/tasks/_inc_extra_configs.yml
+++ b/tasks/_inc_extra_configs.yml
@@ -1,0 +1,23 @@
+---
+
+- name: Install extra execution host configs
+  template:
+    src: "{{ item.template }}"
+    dest: "{{ slurm_config_dir }}/{{ item.name }}"
+    backup: yes
+  with_items:
+    - name: acct_gather.conf
+      config: slurm_acct_gather_config
+      template: generic.conf.j2
+    - name: cgroup.conf
+      config: slurm_cgroup_config
+      template: generic.conf.j2
+    - name: gres.conf
+      config: slurm_gres_config
+      template: gres.conf.j2
+  loop_control:
+    label: "{{ item.name }}"
+  when: item.config in vars
+  notify:
+    - reload slurmctld
+    - reload slurmd

--- a/tasks/munge.yml
+++ b/tasks/munge.yml
@@ -16,6 +16,8 @@
     group: munge
     mode: 0400
   when: slurm_munge_key is defined
+  notify:
+    - restart munge
 
 - name: Ensure Munge is enabled and running
   service:

--- a/tasks/slurmctld.yml
+++ b/tasks/slurmctld.yml
@@ -29,20 +29,5 @@
   include_tasks: _inc_create_config_dir.yml
   when: slurm_create_dirs
 
-- name: Install extra execution host configs
-  template:
-    src: "{{ item.template }}"
-    dest: "{{ slurm_config_dir }}/{{ item.name }}"
-    backup: yes
-  with_items:
-    - name: cgroup.conf
-      config: slurm_cgroup_config
-      template: "generic.conf.j2"
-    - name: gres.conf
-      config: slurm_gres_config
-      template: "gres.conf.j2"
-  loop_control:
-    label: "{{ item.name }}"
-  when: item.config in vars
-  notify:
-    - reload slurmctld
+- name: Include extra config creation tasks
+  include_tasks: _inc_extra_configs.yml

--- a/tasks/slurmctld.yml
+++ b/tasks/slurmctld.yml
@@ -23,7 +23,7 @@
     group: "{{ __slurm_group_name }}"
     mode: 0755
     state: directory
-  when: slurm_create_dirs and not __slurm_config_merged.SlurmctldLogFile.startswith('__omit_place_holder')
+  when: slurm_create_dirs and __slurm_config_merged.SlurmctldLogFile != omit
 
 - name: Include config dir creation tasks
   include_tasks: _inc_create_config_dir.yml

--- a/tasks/slurmctld.yml
+++ b/tasks/slurmctld.yml
@@ -23,4 +23,4 @@
     group: "{{ __slurm_group_name }}"
     mode: 0755
     state: directory
-  when: slurm_create_dirs and __slurm_config_merged.SlurmctldLogFile
+  when: slurm_create_dirs and not __slurm_config_merged.SlurmctldLogFile.startswith('__omit_place_holder')

--- a/tasks/slurmctld.yml
+++ b/tasks/slurmctld.yml
@@ -24,3 +24,25 @@
     mode: 0755
     state: directory
   when: slurm_create_dirs and not __slurm_config_merged.SlurmctldLogFile.startswith('__omit_place_holder')
+
+- name: Include config dir creation tasks
+  include_tasks: _inc_create_config_dir.yml
+  when: slurm_create_dirs
+
+- name: Install extra execution host configs
+  template:
+    src: "{{ item.template }}"
+    dest: "{{ slurm_config_dir }}/{{ item.name }}"
+    backup: yes
+  with_items:
+    - name: cgroup.conf
+      config: slurm_cgroup_config
+      template: "generic.conf.j2"
+    - name: gres.conf
+      config: slurm_gres_config
+      template: "gres.conf.j2"
+  loop_control:
+    label: "{{ item.name }}"
+  when: item.config in vars
+  notify:
+    - reload slurmctld

--- a/tasks/slurmd.yml
+++ b/tasks/slurmd.yml
@@ -23,7 +23,7 @@
     group: "{{ __slurm_group_name }}"
     mode: 0755
     state: directory
-  when: slurm_create_dirs and not __slurm_config_merged.SlurmdLogFile.startswith('__omit_place_holder')
+  when: slurm_create_dirs and __slurm_config_merged.SlurmdLogFile != omit
 
 - name: Include config dir creation tasks
   include_tasks: _inc_create_config_dir.yml

--- a/tasks/slurmd.yml
+++ b/tasks/slurmd.yml
@@ -23,7 +23,7 @@
     group: "{{ __slurm_group_name }}"
     mode: 0755
     state: directory
-  when: slurm_create_dirs and __slurm_config_merged.SlurmdLogFile
+  when: slurm_create_dirs and not __slurm_config_merged.SlurmdLogFile.startswith('__omit_place_holder')
 
 - name: Include config dir creation tasks
   include_tasks: _inc_create_config_dir.yml

--- a/tasks/slurmd.yml
+++ b/tasks/slurmd.yml
@@ -29,20 +29,5 @@
   include_tasks: _inc_create_config_dir.yml
   when: slurm_create_dirs
 
-- name: Install extra execution host configs
-  template:
-    src: "{{ item.template }}"
-    dest: "{{ slurm_config_dir }}/{{ item.name }}"
-    backup: yes
-  with_items:
-    - name: cgroup.conf
-      config: slurm_cgroup_config
-      template: "generic.conf.j2"
-    - name: gres.conf
-      config: slurm_gres_config
-      template: "gres.conf.j2"
-  loop_control:
-    label: "{{ item.name }}"
-  when: item.config in vars
-  notify:
-    - reload slurmd
+- name: Include extra config creation tasks
+  include_tasks: _inc_extra_configs.yml

--- a/tasks/slurmd.yml
+++ b/tasks/slurmd.yml
@@ -31,10 +31,18 @@
 
 - name: Install extra execution host configs
   template:
-    src: generic.conf.j2
+    src: "{{ item.template }}"
     dest: "{{ slurm_config_dir }}/{{ item.name }}"
     backup: yes
   with_items:
     - name: cgroup.conf
       config: slurm_cgroup_config
+      template: "generic.conf.j2"
+    - name: gres.conf
+      config: slurm_gres_config
+      template: "gres.conf.j2"
+  loop_control:
+    label: "{{ item.name }}"
   when: item.config in vars
+  notify:
+    - reload slurmd

--- a/tasks/slurmdbd.yml
+++ b/tasks/slurmdbd.yml
@@ -11,7 +11,7 @@
     dest: "{{ slurm_config_dir }}/{{ item.name }}"
     owner: "{{ __slurm_user_name }}"
     group: root
-    mode: 0400
+    mode: 0600
   with_items:
     - name: slurmdbd.conf
       config: __slurmdbd_config_merged

--- a/tasks/slurmdbd.yml
+++ b/tasks/slurmdbd.yml
@@ -27,4 +27,4 @@
     group: "{{ __slurm_group_name }}"
     mode: 0755
     state: directory
-  when: slurm_create_dirs and not __slurmdbd_config_merged.LogFile.startswith('__omit_place_holder')
+  when: slurm_create_dirs and __slurmdbd_config_merged.LogFile != omit

--- a/tasks/slurmdbd.yml
+++ b/tasks/slurmdbd.yml
@@ -8,10 +8,15 @@
 - name: Install slurmdbd.conf
   template:
     src: generic.conf.j2
-    dest: "{{ slurm_config_dir }}/slurmdbd.conf"
+    dest: "{{ slurm_config_dir }}/{{ item.name }}"
     owner: "{{ __slurm_user_name }}"
     group: root
     mode: 0400
+  with_items:
+    - name: slurmdbd.conf
+      config: __slurmdbd_config_merged
+  loop_control:
+    label: "{{ item.name }}"
   notify:
     - reload slurmdbd
 

--- a/tasks/slurmdbd.yml
+++ b/tasks/slurmdbd.yml
@@ -5,6 +5,19 @@
     name: "{{ __slurm_packages.slurmdbd }}"
     state: "{{ 'latest' if slurm_upgrade else 'present' }}"
 
+- name: Create slurm log directory
+  file:
+    path: "{{ __slurmdbd_config_merged.LogFile | dirname }}"
+    owner: "{{ __slurm_user_name }}"
+    group: "{{ __slurm_group_name }}"
+    mode: 0755
+    state: directory
+  when: slurm_create_dirs and __slurmdbd_config_merged.LogFile != omit
+
+- name: Include config dir creation tasks
+  include_tasks: _inc_create_config_dir.yml
+  when: slurm_create_dirs
+
 - name: Install slurmdbd.conf
   template:
     src: generic.conf.j2
@@ -19,12 +32,3 @@
     label: "{{ item.name }}"
   notify:
     - reload slurmdbd
-
-- name: Create slurm log directory
-  file:
-    path: "{{ __slurmdbd_config_merged.LogFile | dirname }}"
-    owner: "{{ __slurm_user_name }}"
-    group: "{{ __slurm_group_name }}"
-    mode: 0755
-    state: directory
-  when: slurm_create_dirs and __slurmdbd_config_merged.LogFile != omit

--- a/tasks/slurmdbd.yml
+++ b/tasks/slurmdbd.yml
@@ -27,4 +27,4 @@
     group: "{{ __slurm_group_name }}"
     mode: 0755
     state: directory
-  when: slurm_create_dirs and __slurmdbd_config_merged.LogFile
+  when: slurm_create_dirs and not __slurmdbd_config_merged.LogFile.startswith('__omit_place_holder')

--- a/templates/gres.conf.j2
+++ b/templates/gres.conf.j2
@@ -1,0 +1,10 @@
+##
+## This file is maintained by Ansible - ALL MODIFICATIONS WILL BE REVERTED
+##
+
+{% set conf = lookup('vars', item.config) %}
+{% for gres in conf %}
+{% if gres['NodeName'] is not none %}
+NodeName={{ gres['NodeName'] }}{% for key in gres | sort %}{% if key != 'NodeName' %} {{ key }}={{ gres[key] }}{% endif %}{% endfor %}
+{% endif %}
+{% endfor %}

--- a/templates/gres.conf.j2
+++ b/templates/gres.conf.j2
@@ -6,5 +6,6 @@
 {% for gres in conf %}
 {% if gres['NodeName'] is not none %}
 NodeName={{ gres['NodeName'] }}{% for key in gres | sort %}{% if key != 'NodeName' %} {{ key }}={{ gres[key] }}{% endif %}{% endfor %}
+
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
Please consider merging these additions/fixes.

1. MUNGE should be restarted after deploying a key
2. Added the ability to deploy a gres.conf along with cgroup.conf, important when using nodes with GPUs
3. slurmdbd.yml was missing a loop, resulting in _item_ being undefined in generic.conf.j2.
4. When no log file is given (which is the default on RedHat), this role fails with
`fatal: [***]: FAILED! => {"changed": false, "msg": "There was an issue creating  as requested: [Errno 2] No such file or directory: ''", "path": "", "state": "absent"}`.
Since omitting a value sets it to _\_\_omit_place_holder\_\<sha1 hash here\>_ internally instead of `None`, _slurm_config_merged.LogFile is always defined. I've changed the condition to check for these placeholders instead. I don't like it, but it's the only thing I found that works.
5. Added a more extensive example to the README file, because the minimal one does not showcase this role very well.

Tested on Ansible 2.5.1 & 2.7.10