### PR TITLE
Added cluster creation to slurmdb install

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,6 +17,10 @@ slurmd_service_name: slurmd
 slurmctld_service_name: slurmctld
 slurmdbd_service_name: slurmdbd
 
+#Cluster name for slurm config. This is required to correctly setup slurmdbd and attune it to the slurm config.
+__slurm_cluster_name: cluster
+__cluster_not_setup: true #Default value. Is modified if cluster already exists.
+
 __slurm_user_name: "{{ (slurm_user | default({})).name | default('slurm') }}"
 # TODO: this could be incorrect, use the group collection from galaxyproject.galaxy
 __slurm_group_name: "{{ (slurm_user | default({})).group | default(omit) }}"
@@ -28,7 +32,7 @@ __slurm_config_default:
   AuthType: auth/munge
   CryptoType: crypto/munge
   SlurmUser: "{{ __slurm_user_name }}"
-  ClusterName: cluster
+  ClusterName: "{{ __slurm_cluster_name }}"
   # default is proctrack/cgroup which is the best but also less than 100% chance of working e.g. in docker
   ProctrackType: proctrack/pgid
   # slurmctld options

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,3 +39,7 @@
     enabled: yes
     state: started
   when: "'slurmexechosts' in group_names or 'exec' in slurm_roles"
+
+- name: Setup cluster on slurmdb
+  include_tasks: slurmdbd_cluster.yml
+  when: "'slurmdbdservers' in group_names or 'dbd' in slurm_roles"

--- a/tasks/slurmdbd.yml
+++ b/tasks/slurmdbd.yml
@@ -23,3 +23,22 @@
     mode: 0755
     state: directory
   when: slurm_create_dirs and __slurmdbd_config_merged.LogFile
+
+- name: Check for existence of cluster in db.
+  register: cluster_check
+  shell: "sacctmgr -n list cluster | cut -f 4 -d ' '"
+  become: yes
+  become_user: root
+
+- name: set cluster_check_boolean
+  set_fact:
+      __cluster_not_setup: false
+  when: cluster_check.stdout == "cluster"
+
+- name: Create the slurmdbd cluster
+  command: sacctmgr -i -n add cluster {{ __slurm_cluster_name }}
+  become: yes
+  become_user: root
+  notify:
+    - reload slurmdbd
+  when: __cluster_not_setup

--- a/tasks/slurmdbd.yml
+++ b/tasks/slurmdbd.yml
@@ -23,22 +23,3 @@
     mode: 0755
     state: directory
   when: slurm_create_dirs and __slurmdbd_config_merged.LogFile
-
-- name: Check for existence of cluster in db.
-  register: cluster_check
-  shell: "sacctmgr -n list cluster | cut -f 4 -d ' '"
-  become: yes
-  become_user: root
-
-- name: set cluster_check_boolean
-  set_fact:
-      __cluster_not_setup: false
-  when: cluster_check.stdout == "cluster"
-
-- name: Create the slurmdbd cluster
-  command: sacctmgr -i -n add cluster {{ __slurm_cluster_name }}
-  become: yes
-  become_user: root
-  notify:
-    - reload slurmdbd
-  when: __cluster_not_setup

--- a/tasks/slurmdbd_cluster.yml
+++ b/tasks/slurmdbd_cluster.yml
@@ -1,0 +1,20 @@
+---
+
+- name: Check for existence of cluster in db.
+  register: cluster_check
+  shell: "sacctmgr -n list cluster | cut -f 4 -d ' '"
+  become: yes
+  become_user: root
+
+- name: set cluster_check_boolean
+  set_fact:
+      __cluster_not_setup: false
+  when: cluster_check.stdout == "cluster"
+
+- name: Create the slurmdbd cluster
+  command: sacctmgr -i -n add cluster {{ __slurm_cluster_name }}
+  become: yes
+  become_user: root
+  notify:
+    - reload slurmdbd
+  when: __cluster_not_setup


### PR DESCRIPTION
If you install slurmdb and you want to use sacct to look at jobs, you need to create a "cluster" in the database with the same name as the one in slurm.conf.

This PR adds ansible code to do this.