### PR TITLE
Debian Buster is now supported

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,7 @@
 ---
+- name: systemd reload
+  systemd:
+    daemon_reload: yes
 
 - name: reload slurmd
   service:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -45,6 +45,7 @@ galaxy_info:
     versions:
       - jessie
       - stretch
+      - buster
   - name: Ubuntu
     versions:
       - xenial

--- a/tasks/slurmdbd.yml
+++ b/tasks/slurmdbd.yml
@@ -8,10 +8,13 @@
 - name: Install slurmdbd.conf
   template:
     src: generic.conf.j2
-    dest: "{{ slurm_config_dir }}/slurmdbd.conf"
+    dest: "{{ slurm_config_dir }}/{{ item.name }}"
     owner: "{{ __slurm_user_name }}"
     group: root
     mode: 0400
+  with_items:
+    - name: slurmdbd.conf
+      config: __slurmdbd_config_merged
   notify:
     - reload slurmdbd
 
@@ -23,3 +26,19 @@
     mode: 0755
     state: directory
   when: slurm_create_dirs and __slurmdbd_config_merged.LogFile
+
+- name: Directory of Pidfile must exist
+  file:
+    state: directory
+    path: "{{ __slurmdbd_config_merged.PidFile | dirname }}"
+  when: __slurmdbd_config_merged.PidFile is defined
+
+- name: Service slurmdbd , option PIDFile
+  lineinfile:
+    path: /lib/systemd/system/slurmdbd.service
+    regexp: 'PIDFile'
+    line: "PIDFile={{ __slurmdbd_config_merged.PidFile }}"
+  when: __slurmdbd_config_merged.PidFile is defined
+  notify:
+    - systemd reload
+    - reload slurmdbd


### PR DESCRIPTION
- Debian Buster is now supported and working 
-  Fix #6
  - on tasks `Install slurmdbd.conf` , fix AnsibleUndefinedVariable: 
'item' is undefined"
- Create directory path of PIDfile
- Modify the systemd service with PIDfile
- Add Handler to reload systemd

Still a bug exist on a refresh install with `Ensure slurmdbd is enabled and 
running` will failed as it's running before `systemd daemon-reload` handler