### PR TITLE
Ansible lint

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,35 +1,35 @@
 ---
 - name: restart munge
-  service:
+  ansible.builtin.service:
     name: munge
     state: restarted
 
 - name: reload slurmd
-  service:
+  ansible.builtin.service:
     name: "{{ slurmd_service_name }}"
     state: reloaded
   when: "slurm_start_services and ('slurmexechosts' in group_names or 'exec' in slurm_roles)"
 
 - name: restart slurmd
-  service:
+  ansible.builtin.service:
     name: "{{ slurmd_service_name }}"
     state: restarted
   when: "slurm_start_services and ('slurmexechosts' in group_names or 'exec' in slurm_roles)"
 
 - name: reload slurmctld
-  service:
+  ansible.builtin.service:
     name: "{{ slurmctld_service_name }}"
     state: reloaded
   when: "slurm_start_services and ('slurmservers' in group_names or 'controller' in slurm_roles)"
 
 - name: restart slurmctld
-  service:
+  ansible.builtin.service:
     name: "{{ slurmctld_service_name }}"
     state: restarted
   when: "slurm_start_services and ('slurmservers' in group_names or 'controller' in slurm_roles)"
 
 - name: reload slurmdbd
-  service:
+  ansible.builtin.service:
     name: "{{ slurmdbd_service_name }}"
     state: reloaded
   when: "slurm_start_services and ('slurmdbdservers' in group_names or 'dbd' in slurm_roles)"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,34 +1,34 @@
 ---
-- name: restart munge
+- name: Restart munge
   ansible.builtin.service:
     name: munge
     state: restarted
 
-- name: reload slurmd
+- name: Reload slurmd
   ansible.builtin.service:
     name: "{{ slurmd_service_name }}"
     state: reloaded
   when: "slurm_start_services and ('slurmexechosts' in group_names or 'exec' in slurm_roles)"
 
-- name: restart slurmd
+- name: Restart slurmd
   ansible.builtin.service:
     name: "{{ slurmd_service_name }}"
     state: restarted
   when: "slurm_start_services and ('slurmexechosts' in group_names or 'exec' in slurm_roles)"
 
-- name: reload slurmctld
+- name: Reload slurmctld
   ansible.builtin.service:
     name: "{{ slurmctld_service_name }}"
     state: reloaded
   when: "slurm_start_services and ('slurmservers' in group_names or 'controller' in slurm_roles)"
 
-- name: restart slurmctld
+- name: Restart slurmctld
   ansible.builtin.service:
     name: "{{ slurmctld_service_name }}"
     state: restarted
   when: "slurm_start_services and ('slurmservers' in group_names or 'controller' in slurm_roles)"
 
-- name: reload slurmdbd
+- name: Reload slurmdbd
   ansible.builtin.service:
     name: "{{ slurmdbd_service_name }}"
     state: reloaded

--- a/tasks/_inc_extra_configs.yml
+++ b/tasks/_inc_extra_configs.yml
@@ -20,5 +20,5 @@
     label: "{{ item.name }}"
   when: item.config in vars
   notify:
-    - reload slurmctld
-    - reload slurmd
+    - Reload slurmctld
+    - Reload slurmd

--- a/tasks/common.yml
+++ b/tasks/common.yml
@@ -24,8 +24,8 @@
     group: root
     mode: 0444
   notify:
-    - restart slurmd
-    - restart slurmctld
+    - Restart slurmd
+    - Restart slurmctld
 
 - name: Include munge tasks
   ansible.builtin.include_tasks: munge.yml

--- a/tasks/munge.yml
+++ b/tasks/munge.yml
@@ -17,7 +17,7 @@
     mode: 0400
   when: slurm_munge_key is defined
   notify:
-    - restart munge
+    - Restart munge
 
 - name: Ensure Munge is enabled and running
   ansible.builtin.service:

--- a/tasks/slurmctld.yml
+++ b/tasks/slurmctld.yml
@@ -14,7 +14,7 @@
     state: directory
   when: slurm_create_dirs
   notify:
-    - reload slurmctld
+    - Reload slurmctld
 
 - name: Create slurm log directory
   ansible.builtin.file:

--- a/tasks/slurmd.yml
+++ b/tasks/slurmd.yml
@@ -14,7 +14,7 @@
     state: directory
   when: slurm_create_dirs
   notify:
-    - reload slurmd
+    - Reload slurmd
 
 - name: Create slurm log directory
   ansible.builtin.file:

--- a/tasks/slurmdbd.yml
+++ b/tasks/slurmdbd.yml
@@ -31,4 +31,4 @@
   loop_control:
     label: "{{ item.name }}"
   notify:
-    - reload slurmdbd
+    - Reload slurmdbd


### PR DESCRIPTION
Fix 2  ansible-lint warning : 
- Use FQCN for builtin module actions
- All names should start with an uppercase letter. (warning)

Rename notify to reflect the name of `All names should start with an uppercase letter.` in the handlers file