### PR TITLE
allowed potentially multiple SlurmctldHost as one might have backupcontrollers.

### DIFF
--- a/templates/slurm.conf.j2
+++ b/templates/slurm.conf.j2
@@ -11,7 +11,13 @@ ControlMachine=localhost
 {% for key in __slurm_config_merged | sort %}
 {% set val = __slurm_config_merged[key] %}
 {% if val is not none and val != omit %}
+{% if key == "SlurmctldHost" and val is iterable and val is not string %}
+{% for host in val %}
+SlurmctldHost={{ host }}
+{% endfor %}
+{% else %}
 {{ key }}={{ 'YES' if val is sameas true else ('NO' if val is sameas false else val) }}
+{% endif %}
 {% endif %}
 {% endfor %}
 


### PR DESCRIPTION
Consider the case where you want to have a backupcontroller. This is currently not possible as yaml/ansible is not happy with duplicate keys, so the previous key would simply be overwritten. Instead if we allow keys to be either string, or lists of strings that would expand to multiple instances of the key in the slurm.conf file we would have the desired effect e.g.

``` yaml
SlurmctldHost: [node-1,node-2]
```

would expand to

``` conf
SlurmctldHost=node-1
SlurmctldHost=node-2
```

While 
``` yaml
SlurmctldHost: node-1
```
would expand to

``` conf
SlurmctldHost=node-1
```
