### PR TITLE
fix typo: reload slurmdbd->Reload slurmdbd

### DIFF
--- a/tasks/slurmdbd_cluster.yml
+++ b/tasks/slurmdbd_cluster.yml
@@ -16,5 +16,5 @@
   become: yes
   become_user: root
   notify:
-    - reload slurmdbd
+    - Reload slurmdbd
   when: __cluster_not_setup


### PR DESCRIPTION
I think this is a Typo. The handler `reload slurmdbd` doesn't exist.

from handlers/main.yml
```
- name: Reload slurmdbd
  ansible.builtin.service:
    name: "{{ slurmdbd_service_name }}"
    state: reloaded
  when: "slurm_start_services and ('slurmdbdservers' in group_names or 'dbd' in slurm_roles)"
```