### PR TITLE
Remove key 'SlurmctldPidFile' from __slurmdbd_config_default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -91,6 +91,5 @@ __slurmdbd_config_default:
   AuthType: auth/munge
   DbdPort: 6819
   SlurmUser: "{{ __slurm_user_name }}"
-  SlurmctldPidFile: "{{ __slurm_run_dir ~ '/slurmdbd.pid' if __slurm_debian else omit }}"
   LogFile: "{{ __slurm_log_dir ~ '/slurmdbd.log' if __slurm_debian else omit }}"
 __slurmdbd_config_merged: "{{ __slurmdbd_config_default | combine(slurmdbd_config | default({})) }}"


### PR DESCRIPTION
The existence of this key in slurmdbd.conf causes slurmdbd to fail to start on slurm version 19.05.5 (Ubuntu 20.04) and 21.08.5 (Ubuntu 22.04).

```
Aug 03 02:30:50 staging-pulsar systemd[1]: Starting Slurm DBD accounting daemon...
Aug 03 02:30:50 staging-pulsar slurmdbd[374770]: error: _parse_next_key: Parsing error at unrecognized key: SlurmctldPidFile
Aug 03 02:30:50 staging-pulsar slurmdbd[374770]: error: Parse error in file /etc/slurm-llnl/slurmdbd.conf line 11: "SlurmctldPidFile=/run/slurmdbd.pid"
Aug 03 02:30:50 staging-pulsar systemd[1]: slurmdbd.service: Control process exited, code=exited, status=1/FAILURE
Aug 03 02:30:50 staging-pulsar slurmdbd[374770]: fatal: Could not open/read/parse slurmdbd.conf file /etc/slurm-llnl/slurmdbd.conf
```

Maybe this needs to be kept conditional on os version. Unfortunately I can't find anything online about the deprecation of this key.