### PR TITLE
Capitalize 'Reload slurmdbd' notification

### DIFF
--- a/tasks/slurmdbd_cluster.yml
+++ b/tasks/slurmdbd_cluster.yml
@@ -16,5 +16,5 @@
   become: yes
   become_user: root
   notify:
-    - reload slurmdbd
+    - Reload slurmdbd
   when: __cluster_not_setup


### PR DESCRIPTION
When setting up my cluster, the `Reload slurmdbd` handler failed to fire until I updated the notification to match.

