### PR TITLE
Fix typo in handler name

### DIFF
--- a/tasks/slurmdbd_cluster.yml
+++ b/tasks/slurmdbd_cluster.yml
@@ -16,5 +16,5 @@
   become: yes
   become_user: root
   notify:
-    - reload slurmdbd
+    - Reload slurmdbd
   when: __cluster_not_setup


### PR DESCRIPTION
Fix the typo when notifying the 'Reload slurmdbd' handler