### PR TITLE
use builtin ansible-managed system. This allows for easy modification…

### DIFF
--- a/templates/generic.conf.j2
+++ b/templates/generic.conf.j2
@@ -1,6 +1,4 @@
-##
-## This file is maintained by Ansible - ALL MODIFICATIONS WILL BE REVERTED
-##
+{{ ansible_managed | comment }}
 
 {% set conf = lookup('vars', item.config) %}
 {% for key in conf | sort %}

--- a/templates/gres.conf.j2
+++ b/templates/gres.conf.j2
@@ -1,6 +1,4 @@
-##
-## This file is maintained by Ansible - ALL MODIFICATIONS WILL BE REVERTED
-##
+{{ ansible_managed | comment }}
 
 {% set conf = lookup('vars', item.config) %}
 {% for gres in conf %}

--- a/templates/logrotate.j2
+++ b/templates/logrotate.j2
@@ -1,6 +1,9 @@
+{{ ansible_managed | comment }}
+
 ##
 # Slurm Logrotate Configuration
 ##
+
 # TODO: this ignores the actual *LogFile values
 {{ '/var/log/slurm-llnl' if __slurm_debian else '/var/log/slurm' }}/*.log {
 	compress

--- a/templates/slurm.conf.j2
+++ b/templates/slurm.conf.j2
@@ -1,6 +1,4 @@
-##
-## This file is maintained by Ansible - ALL MODIFICATIONS WILL BE REVERTED
-##
+{{ ansible_managed | comment }}
 
 {% if 'ControlMachine' not in __slurm_config_merged and 'SlurmctldHost' not in __slurm_config_merged %}
 # Default, define SlurmctldHost or ControlMachine to override


### PR DESCRIPTION
This allows for easy modification and is backwards compatible.

By default, it will say "managed by Ansible" but can be customized a lot more in the ansible.cfg e.g. my own

```conf
# ansible.cfg

[defaults]
ansible_managed = This file is maintained by Ansible - ALL MODIFICATIONS WILL BE REVERTED.%n
  template: {file}
  date:     %Y-%m-%d %H:%M:%S
  user:     {uid}
  host:     {host}
```

This improves traceability by letting anyone see who and from what system 