### PR TITLE
Restart slurmd and slurmctld after a Slurm upgrade

### DIFF
--- a/tasks/common.yml
+++ b/tasks/common.yml
@@ -4,6 +4,9 @@
   ansible.builtin.package:
     name: "{{ __slurm_packages.client }}"
     state: "{{ 'latest' if slurm_upgrade else 'present' }}"
+  notify:
+    - Restart slurmd
+    - Restart slurmctld
 
 - name: Include config dir creation tasks
   ansible.builtin.include_tasks: _inc_create_config_dir.yml


### PR DESCRIPTION
Make sure to execute the correct Slurm after the upgrade. Otherwise, this may cause issues when reloading the service during logrotate since some files changed on the system.