### PR TITLE
Restart slurm services after a Slurm upgrade

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -10,6 +10,12 @@
     state: reloaded
   when: "slurm_start_services and ('slurmdbdservers' in group_names or 'dbd' in slurm_roles)"
 
+- name: Restart slurmdbd
+  ansible.builtin.service:
+    name: "{{ slurmdbd_service_name }}"
+    state: restarted
+  when: "slurm_start_services and ('slurmdbdservers' in group_names or 'dbd' in slurm_roles)"
+
 - name: Reload slurmctld
   ansible.builtin.service:
     name: "{{ slurmctld_service_name }}"

--- a/tasks/slurmctld.yml
+++ b/tasks/slurmctld.yml
@@ -4,6 +4,8 @@
   ansible.builtin.package:
     name: "{{ __slurm_packages.slurmctld }}"
     state: "{{ 'latest' if slurm_upgrade else 'present' }}"
+  notify:
+    - Restart slurmctld
 
 - name: Create slurm state directory
   ansible.builtin.file:

--- a/tasks/slurmd.yml
+++ b/tasks/slurmd.yml
@@ -4,6 +4,8 @@
   ansible.builtin.package:
     name: "{{ __slurm_packages.slurmd }}"
     state: "{{ 'latest' if slurm_upgrade else 'present' }}"
+  notify:
+    - Restart slurmd
 
 - name: Create slurm spool directory
   ansible.builtin.file:

--- a/tasks/slurmdbd.yml
+++ b/tasks/slurmdbd.yml
@@ -4,6 +4,8 @@
   ansible.builtin.package:
     name: "{{ __slurm_packages.slurmdbd }}"
     state: "{{ 'latest' if slurm_upgrade else 'present' }}"
+  notify:
+    - Restart slurmdbd
 
 - name: Create slurm log directory
   ansible.builtin.file:


### PR DESCRIPTION
Make sure to execute the correct Slurm after the upgrade. Otherwise, this may cause issues when reloading the service during logrotate since some files changed on the system.