### PR TITLE
Change min_ansible_version to string format

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
   description: Install and manage the Slurm Workload Manager
   company: The Galaxy Project
   license: MIT
-  min_ansible_version: 2.5
+  min_ansible_version: "2.5"
   github_branch: main
   platforms:
     - name: EL


### PR DESCRIPTION
Per the Ansible spec, this is a string and YAML requires quotes around numbers to force a string.