### PR TITLE
Implement self building debs

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,8 @@
 ---
 
+self_build_slurm: false
+build_again: false
+slurm_version: "25.11.1"
 slurm_upgrade: false
 slurm_roles: []
 slurm_partitions: []
@@ -85,7 +88,16 @@ __slurm_redhat_packages:
   slurmd: [munge, slurm, slurm-slurmd]
   slurmdbd: [munge, slurm-slurmdbd]
 
-__slurm_packages: "{{ __slurm_debian_packages if __slurm_debian else __slurm_redhat_packages }}"
+__build_deps: [build-essential, fakeroot, devscripts, equivs]
+
+_slurm_self_packages:
+  client: [slurm-smd, slurm-smd-client]
+  slurmctld: [slurm-smd, slurm-smd-client, slurm-smd-slurmctld]
+  slurmd: [slurm-smd, slurm-smd-client, slurm-smd-slurmd]
+  slurmdbd: [slurm-smd, slurm-smd-client, slurm-smd-slurmdbd]
+  all: [slurm-smd, slurm-smd-client, slurm-smd-slurmctld, slurm-smd-slurmd, slurm-smd-slurmdbd]
+
+__slurm_packages: "{{ _slurm_self_packages if self_build_slurm else (__slurm_debian_packages if __slurm_debian else __slurm_redhat_packages) }}"
 
 __slurmdbd_config_default:
   AuthType: auth/munge

--- a/tasks/build.yml
+++ b/tasks/build.yml
@@ -1,0 +1,88 @@
+---
+
+- name: Build slurm in controller
+  when: "('slurmservers' in group_names or 'controller' in slurm_roles) and build_again"
+  block:
+    - name: Install Slurm build requirements
+      ansible.builtin.package:
+        name: "{{ __build_deps }}"
+        state: present
+
+    - name: Download Slurm source
+      ansible.builtin.get_url:
+        url: "https://download.schedmd.com/slurm/slurm-{{ slurm_version }}.tar.bz2"
+        mode: "755"
+        dest: "/tmp/slurm-{{ slurm_version }}.tar.bz2"
+
+    - name: Unpack Slurm source
+      ansible.builtin.unarchive:
+        src: "/tmp/slurm-{{ slurm_version }}.tar.bz2"
+        dest: /tmp/
+        remote_src: true
+
+    - name: Install Slurm package dependencies
+      ansible.builtin.command:
+        cmd: mk-build-deps -i -t 'apt-get -y' debian/control
+        chdir: "/tmp/slurm-{{ slurm_version }}"
+
+    - name: Build Slurm packages
+      ansible.builtin.command:
+        cmd: debuild -b -uc -us -j4
+        chdir: "/tmp/slurm-{{ slurm_version }}"
+      tags: rebuild_slurm
+
+    - name: Copy files to controller
+      ansible.builtin.fetch:
+        src: "/tmp/{{ item }}_{{ slurm_version }}-1_amd64.deb"
+        dest: /tmp/debs/{{ item }}.deb
+        flat: true
+      loop: "{{ __slurm_packages.all }}"
+
+    - name: Put built debs in correct folder
+      ansible.builtin.copy:
+        src: /tmp/debs/
+        dest: /var/backups/slurm_debs/
+        mode: "0755"
+
+- name: Put built debs in all nodes
+  ansible.builtin.copy:
+    src: /var/backups/slurm_debs/
+    dest: /var/backups/slurm_debs/
+    mode: "0755"
+  register: copy_result
+
+- name: Install dependency
+  ansible.builtin.package:
+    name: dpkg-dev
+    state: "present"
+
+- name: Create script to refresh the index
+  ansible.builtin.copy:
+    dest: /usr/local/bin/update-slurm-repo
+    mode: "0755"
+    content: |
+      #!/bin/bash
+      cd /var/backups/slurm_debs
+      dpkg-scanpackages . /dev/null | gzip -9c > Packages.gz
+      apt-get update
+- name: Run the index update for the first time
+  ansible.builtin.command: /usr/local/bin/update-slurm-repo
+  when: copy_result.changed
+  changed_when: true
+
+- name: Add local repo to APT sources
+  ansible.builtin.apt_repository:
+    repo: "deb [trusted=yes] file:/var/backups/slurm_debs ./"
+    state: present
+    filename: slurm_repo
+
+- name: Pin slurm-smd to version
+  ansible.builtin.copy:
+    dest: "/etc/apt/preferences.d/pin-{{ item }}"
+    content: |
+      Package: {{ item }}
+      Pin: version {{ slurm_version }}-1
+      Pin-Priority: 1001
+    mode: "0644"
+  loop: "{{ __slurm_packages.all }}"
+  tags: pin_package

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,9 @@
 ---
 
+- name: Include build task
+  ansible.builtin.include_tasks: build.yml
+  when: self_build_slurm
+
 - name: Include user creation tasks
   ansible.builtin.include_tasks: user.yml
   when: slurm_create_user


### PR DESCRIPTION
The [official](https://slurm.schedmd.com/quickstart_admin.html) slurm guide details a procedure of installing slurm using self-built binaries. For heterogenous clusters with differing distribution versions, using the distribution's slurm isn't an option. Additionally, the latest slurm release is over 2 major versions higher than the latest Ubuntu LTS packages. This pull request implements self building, in the case of debian. There are some differences in the procedure for building RPMs, but using this scaffold, it should be trivial to achieve.