### PR TITLE
Add namespace.yaml config builder

### DIFF
--- a/tasks/_inc_extra_configs.yml
+++ b/tasks/_inc_extra_configs.yml
@@ -16,6 +16,9 @@
     - name: gres.conf
       config: slurm_gres_config
       template: gres.conf.j2
+    - name: namespace.yaml
+      config: namespace_config
+      template: generic.yaml.j2
   loop_control:
     label: "{{ item.name }}"
   when: item.config in vars

--- a/templates/generic.yaml.j2
+++ b/templates/generic.yaml.j2
@@ -1,0 +1,15 @@
+##
+## This file is maintained by Ansible - ALL MODIFICATIONS WILL BE REVERTED
+##
+
+{% set conf = lookup('vars', item.config) %}
+{% for key in conf | sort %}
+{{ key }}:
+{% set val = conf[key] %}
+{% for nkey in val %}
+{% set nval = val[nkey] %}
+{% if nval is not none and nval != omit %}
+    {{nkey }}: {{ 'true' if nval is sameas true else ('false' if nval is sameas false else nval) }}
+{% endif %}
+{% endfor %}
+{% endfor %}


### PR DESCRIPTION
The config file `namespace.yaml` is a rare exception of yaml-based configuration for slurm. This PR implements a way to generate a namespace.yaml.