### PR TITLE
Allow lines not starting in NodeName in GRES template

### DIFF
--- a/templates/gres.conf.j2
+++ b/templates/gres.conf.j2
@@ -7,5 +7,8 @@
 {% if gres['NodeName'] is not none %}
 NodeName={{ gres['NodeName'] }}{% for key in gres | sort %}{% if key != 'NodeName' %} {{ key }}={{ gres[key] }}{% endif %}{% endfor %}
 
+{% else %}
+{% for key in gres %}{{ key }}={{ gres[key] }} {% endfor %}
+
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
As detailed in the official docs for `gres.conf`, it is quite common to start this file with the line "AutoDetect=nvml". This PR makes it possible.