### PR TITLE
Fix permission bug

### DIFF
--- a/tasks/user.yml
+++ b/tasks/user.yml
@@ -17,3 +17,14 @@
     home: "{{ (slurm_user | default({})).home | default(omit) }}"
     shell: "{{ (slurm_user | default({})).shell | default(omit) }}"
     system: "{{ (slurm_user | default({})).system | default('yes') }}"
+
+- name: Ensure slurm user home directory permissions
+  when:
+    - slurm_create_user | default(False)
+    - (slurm_user | default({})).home is defined
+  ansible.builtin.file:
+    path: "{{ (slurm_user | default({})).home }}"
+    state: directory
+    owner: "{{ (slurm_user | default({})).name | default('slurm') }}"
+    group: "{{ (slurm_user | default({})).group | default(omit) }}"
+    mode: "0755"


### PR DESCRIPTION
In Ubuntu distributions, the home directory of the `slurm` user is set to /var/lib/slurm but has improper permissions, leading to daemons producing errors. This PR correctly sets the permissions of the slurm user home directory.