### PR TITLE
Make query task unchangable

### DIFF
--- a/tasks/slurmdbd_cluster.yml
+++ b/tasks/slurmdbd_cluster.yml
@@ -5,6 +5,7 @@
   shell: "sacctmgr -n list cluster | cut -f 4 -d ' '"
   become: yes
   become_user: root
+  changed_when: false
 
 - name: set cluster_check_boolean
   set_fact:


### PR DESCRIPTION
The task querying for the existence of the configured cluster in slurmdb is idempotent, thus should never display as "changed". This PR fixes this UX issue.